### PR TITLE
Fix filters vulnerability against potential username DoS injection

### DIFF
--- a/fail2ban/filter.d/bitwarden.conf
+++ b/fail2ban/filter.d/bitwarden.conf
@@ -2,5 +2,5 @@
 before = common.conf
 
 [Definition]
-failregex = ^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$
+failregex = ^.*?Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$
 ignoreregex =

--- a/fail2ban/filter.d/vaultwarden.conf
+++ b/fail2ban/filter.d/vaultwarden.conf
@@ -2,5 +2,5 @@
 before = common.conf
 
 [Definition]
-failregex = ^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$
+failregex = ^.*?Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$
 ignoreregex =


### PR DESCRIPTION
Fix filters vulnerability against potential username DoS injection by making start of regex ungreedy

See "3. Over greedy pattern matching" at https://fail2ban.readthedocs.io/en/latest/filters.html#filter-security 
Example of injection : "Username or password is incorrect. Try again. IP: (Some IP to DoS). Username: toto"